### PR TITLE
Add support for copying entity to clipboard #8

### DIFF
--- a/src/MIDL/Commands/CopyEntityToClipboard.cs
+++ b/src/MIDL/Commands/CopyEntityToClipboard.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using MIDLParser;
+using static Community.VisualStudio.Toolkit.Windows;
+using OutputWindowPane = Community.VisualStudio.Toolkit.OutputWindowPane;
+
+namespace MIDL
+{
+    [Command(PackageIds.CopyEntityToClipboard)]
+    internal class CopyEntityToClipboard : BaseCommand<CopyEntityToClipboard>
+    {
+        private static readonly Regex _rxIdentifier = new(@"(\w|\d)+");
+
+        protected override Task InitializeCompletedAsync()
+        {
+            Command.Supported = false;
+            return base.InitializeCompletedAsync();
+        }
+
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            try
+            {
+                // Get active text
+                await VS.StatusBar.ShowMessageAsync("Getting identifier...");
+                DocumentView? docView = await VS.Documents.GetActiveDocumentViewAsync();
+                if (docView == null)
+                {
+                    throw new InvalidOperationException("Failed to get active document view");
+                }
+                IWpfTextView textView = docView.TextView;
+                ITextSelection selection = textView.Selection;
+                int position = selection.Start.Position.Position;
+                ITextSnapshotLine lineSnapshot = selection.Start.Position.GetContainingLine();
+                string line = lineSnapshot.GetText();
+                // TODO: Is there anyway to get the parsed items directly? The syntax highlighter
+                // should have already ran a parsing pass.
+                MIDLParser.Document parser = MIDLParser.Document.FromLines(line);
+                parser.Parse();
+                // Get the identifier.
+                // TODO: This is a crude approximation. Add identifier to the parser
+                // Right now it would produce incorrect result for event where the generic parameter is seen as an identifier
+                string id = line;
+                foreach (ParseItem item in parser.Items)
+                {
+                    id = id.Replace(item.Text, "");
+                }
+                id = id.Trim();
+                Match idMatch = _rxIdentifier.Match(id);
+                if (!idMatch.Success)
+                {
+                    throw new InvalidOperationException("Failed to find identifier");
+                }
+                id = idMatch.Value;
+                // Generate header
+                await VS.StatusBar.ShowMessageAsync("Generating file...");
+                PhysicalFile idlFile = await VS.Solutions.GetActiveItemAsync() as PhysicalFile;
+                // TODO: Make it language agnostic
+                ProcessResult result = await idlFile.TransformToHeaderAsync();
+                if (!result.Success)
+                {
+                    throw new InvalidOperationException("Failed to generate header file");
+                }
+                string[] headerFileLines = File.ReadAllLines(result.HeaderFile);
+                List<string> output = new();
+                foreach (string headerLine in headerFileLines)
+                {
+                    // TODO: Make it language agnostic
+                    // TODO: Seem we need a C++ parser to accurately grab the relevant lines...?
+                    if (headerLine.Contains(id) && !headerLine.Contains("struct") && !headerLine.Contains("#") && !headerLine.Contains("namespace"))
+                    {
+                        output.Add(headerLine);
+                    }
+                }
+                Clipboard.SetText(string.Join(Environment.NewLine, output));
+                await VS.StatusBar.ShowMessageAsync("Copied");
+            }
+            catch (Exception ex)
+            {
+                await VS.StatusBar.ShowMessageAsync("Failed to copy to clipboard. See output window for details");
+                await ex.LogAsync();
+            }
+        }
+    }
+}

--- a/src/MIDL/MIDL.csproj
+++ b/src/MIDL/MIDL.csproj
@@ -45,6 +45,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Commands\CopyEntityToClipboard.cs" />
     <Compile Include="Commands\SmartIndent.cs" />
     <Compile Include="Editor\EditorFeatures.cs" />
     <Compile Include="Editor\LanguageFactory.cs" />
@@ -98,6 +99,7 @@
     <Reference Include="Microsoft.VisualStudio.Merge">
       <HintPath>..\..\lib\Microsoft.VisualStudio.Merge.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Design" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/MIDL/MIDLPackage.cs
+++ b/src/MIDL/MIDLPackage.cs
@@ -2,10 +2,15 @@
 global using Community.VisualStudio.Toolkit;
 global using Microsoft.VisualStudio.Shell;
 global using Task = System.Threading.Tasks.Task;
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
+using MIDL.Commands;
 
 namespace MIDL
 {

--- a/src/MIDL/VSCommandTable.cs
+++ b/src/MIDL/VSCommandTable.cs
@@ -27,6 +27,8 @@ namespace MIDL
     internal sealed partial class PackageIds
     {
         public const int MyMenuGroup = 0x0001;
+        public const int FileMenu = 0x0002;
         public const int MyCommand = 0x0100;
+        public const int CopyEntityToClipboard = 0x0101;
     }
 }

--- a/src/MIDL/VSCommandTable.vsct
+++ b/src/MIDL/VSCommandTable.vsct
@@ -11,6 +11,9 @@
       <Group guid="MIDL" id="MyMenuGroup" priority="0x0010">
         <Parent guid="VSMainMenu" id="ItemNode"/>
       </Group>
+      <Group guid="MIDL" id="FileMenu" priority="0x0010">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
+      </Group>
     </Groups>
 
     <!--This section defines the elements the user can interact with, like a menu command or a button
@@ -26,11 +29,27 @@
           <LocCanonicalName>.MIDL.UpdateHeaderFile</LocCanonicalName>
         </Strings>
       </Button>
+      <Button guid="MIDL" id="CopyEntityToClipboard" priority="0x0100" type="Button">
+        <Icon guid="ImageCatalogGuid" id="Interface" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Copy Entity To Clipboard</ButtonText>
+          <LocCanonicalName>.MIDL.CopyEntityToClipboard</LocCanonicalName>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
+  <CommandPlacements>
+    <CommandPlacement guid="MIDL" id="CopyEntityToClipboard" priority="0x0100">
+      <Parent guid="MIDL" id="FileMenu"/>
+    </CommandPlacement>
+  </CommandPlacements>
+
   <VisibilityConstraints>
     <VisibilityItem guid="MIDL" id="MyCommand" context="IdlFileSelected" />
+    <VisibilityItem guid="MIDL" id="CopyEntityToClipboard" context="IdlFileSelected" />
   </VisibilityConstraints>
 
   <Symbols>
@@ -38,8 +57,14 @@
     <GuidSymbol name="MidlEditorFactory" value="{f7d6e464-2c5c-4e02-bc1b-8fe2cde367a3}"/>
     
     <GuidSymbol name="MIDL" value="{be7365f7-d75c-4cfe-94b5-e28bf78459b5}">
+      <!-- Solution explorer context menu -->
       <IDSymbol name="MyMenuGroup" value="0x0001" />
+      
+      <!-- Document context menu -->
+      <IDSymbol name="FileMenu" value="0x0002"/>
+
       <IDSymbol name="MyCommand" value="0x0100" />
+      <IDSymbol name="CopyEntityToClipboard" value="0x0101" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
connect #8 
requires #11

This is an initial implementation, some keyboard/identifier/type combination would produce incorrect result but this is a start.

It is slow because it's always generating all idl files and my project has a ton. I have another PR cooking to only compile the editing file (passed via `IDLFile`).

https://user-images.githubusercontent.com/16918354/197392727-affb8bff-eee0-47f2-95d3-b51dc5da033d.mp4

