### PR TITLE
Enhanced support for proprocessor directives

### DIFF
--- a/src/MIDL/Editor/EditorFeatures.cs
+++ b/src/MIDL/Editor/EditorFeatures.cs
@@ -19,6 +19,7 @@ namespace MIDL
         public override Dictionary<object, string> ClassificationMap { get; } = new()
         {
             { ItemType.Comment, PredefinedClassificationTypeNames.Comment },
+            { ItemType.PreprocessorDirective, PredefinedClassificationTypeNames.PreprocessorKeyword },
             { ItemType.Keyword, PredefinedClassificationTypeNames.Keyword },
             { ItemType.String, PredefinedClassificationTypeNames.String },
             { ItemType.Type, PredefinedClassificationTypeNames.SymbolDefinition },

--- a/src/MIDLParser/DocumentParser.cs
+++ b/src/MIDLParser/DocumentParser.cs
@@ -128,7 +128,7 @@ namespace MIDLParser
             {
                 return ToParseItem(matchDirective, start, ItemType.PreprocessorDirective);
             }
-
+            
             // Keywords
             if (IsMatch(_rxKeyword, lineStr, ref column, out Match matchVar))
             {
@@ -246,7 +246,6 @@ namespace MIDLParser
             public static Error PL002 { get; } = new("PL002", "\"{0}\" is not a valid absolute URI", ErrorCategory.Warning);
             public static Error C2773 { get; } = new("C2773", "#import and #using available only in C++ compiler", ErrorCategory.Error);
         }
-
 
         public event EventHandler? Parsed;
     }

--- a/src/MIDLParser/ItemType.cs
+++ b/src/MIDLParser/ItemType.cs
@@ -5,6 +5,7 @@
         Comment,
         EmptyLine,
         Text,
+        PreprocessorDirective,
         Keyword,
         Type,
         String

--- a/test/MIDLParser.Test/TokenTest.cs
+++ b/test/MIDLParser.Test/TokenTest.cs
@@ -51,8 +51,9 @@ namespace PhotoEditor
             Assert.AreEqual(ItemType.Comment, parser.Items.First().Type);
             Assert.AreEqual(ItemType.Comment, parser.Items[1].Type);
             Assert.AreEqual(ItemType.Comment, parser.Items[2].Type);
-            Assert.AreEqual(ItemType.Keyword, parser.Items[3].Type);
+            Assert.AreEqual(ItemType.PreprocessorDirective, parser.Items[3].Type);
             Assert.AreEqual(ItemType.String, parser.Items[4].Type);
+            Assert.AreEqual(ItemType.Keyword, parser.Items[5].Type);
             Assert.AreEqual(26, parser.Items.Count);
         }
 


### PR DESCRIPTION
The editor now recognises and highlights all the support processor directives, as listed here: https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-directives?view=msvc-170.

TODO:
- Highlight include paths enclosed angle brackets with the same colour as strings.
- Error for unrecognised preprocessor directives.